### PR TITLE
Fixed typo on unpacker.py - it was calling args.req instead of args.r…

### DIFF
--- a/scripts/unpacker.py
+++ b/scripts/unpacker.py
@@ -25,7 +25,7 @@ _bundle[args.fo] = kj
 op = Operator(jwks_bundle=_bundle)
 
 if args.req_jws:
-    _fo, _req = open(args.req).read().rsplit(':', 1)
+    _fo, _req = open(args.req_jws).read().rsplit(':', 1)
     _bundle[_fo] = kj
 
     res = op.unpack_metadata_statement(jwt_ms=_req.strip())


### PR DESCRIPTION
It was calling args.req instead of args.req_jws, landing in an AttributeError exception:

Traceback (most recent call last):
  File "/home/davide/dev/fedoidc/scripts/unpacker.py", line 28, in <module>
    _fo, _req = open(args.req).read().rsplit(':', 1)
AttributeError: 'Namespace' object has no attribute 'req'

Davide